### PR TITLE
Port to 4.03 and some fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+._d/
+*.cmi
+*.cmo
+*.cmx
+*.o
+ppx_blob
+example/quine

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+OCAMLFIND_IGNORE_DUPS_IN = $(shell ocamlfind query compiler-libs)
+export OCAMLFIND_IGNORE_DUPS_IN
+
 SOURCES = ppx_blob.ml
 
 PACKS = ppx_tools

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SOURCES = ppx_blob.ml
 
-PACKS = compiler-libs.common 
+PACKS = ppx_tools
 
 RESULT = ppx_blob
 

--- a/opam
+++ b/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "ppx_blob"
+version: "0.1"
+authors: "John Whitington"
+maintainer: "contact@coherentgraphics.co.uk"
+homepage: "https://github.com/johnwhitington/ppx_blob"
+dev-repo: "https://github.com/johnwhitington/ppx_blob.git"
+bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
+build: [
+  [make "native-code"] {ocaml-native}
+  [make "byte-code"] {!ocaml-native}
+]
+install: [
+  [make "install"]
+]
+remove: [["ocamlfind" "remove" "ppx_blob"]]
+depends: [
+  "ocamlfind" {build & >= "1.5.2"}
+  "ppx_tools" {build}
+]
+available: [ocaml-version >= "4.02.0"]

--- a/ppx_blob.ml
+++ b/ppx_blob.ml
@@ -22,16 +22,22 @@ let blob_mapper argv =
       | { pexp_desc =
           (* Should have name "blob". *)
           Pexp_extension ({ txt = "blob"; loc }, pstr)} ->
-        begin match pstr with
-        | (* Should have a single structure item, which is evaluation of a constant string. *)
-          PStr [{ pstr_desc =
-                  Pstr_eval ({ pexp_loc  = loc;
-                               pexp_desc = Pexp_constant (Const_string (sym, None))}, _)}] ->
-          (* Replace with the contents of the file. *)
-          Exp.constant ~loc (Const_string (getblob ~loc sym, None))
-        | _ ->
+        let error () =
           raise (Location.Error (
                   Location.error ~loc "[%blob] accepts a filename as a string, e.g. [%blob \"file.dat\"]"))
+        in
+        begin match pstr with
+        | (* Should have a single structure item, which is evaluation of a constant string. *)
+          PStr [{ pstr_desc = Pstr_eval ({ pexp_loc = loc } as expr, _) }] ->
+            begin match Ast_convenience.get_str expr with
+            | Some sym ->
+              (* Replace with the contents of the file. *)
+              (* Have to use Ast_helper.with_default_loc to pass the location to Ast_convenience.str until
+                 https://github.com/alainfrisch/ppx_tools/pull/38 is released. *)
+              with_default_loc loc (fun () -> Ast_convenience.str (getblob ~loc sym))
+            | None -> error ()
+            end
+        | _ -> error ()
         end
       (* Delegate to the default mapper. *)
       | x -> default_mapper.expr mapper x;


### PR DESCRIPTION
See the commit messages.

Tested by installing on OPAM 4.02 and 4.03 switches and building and running a "quine" program. `ppx_tools` is installed automatically, and no warnings about `topdirs.cmi` are displayed when building or using `ppx_blob`.

Fixes #2.
