### PR TITLE
Bump version to 0.2

### DIFF
--- a/META
+++ b/META
@@ -1,4 +1,4 @@
 name="ppx_blob"
 description="Include a file as a string at compile time"
-version="0.1"
+version="0.2"
 ppx="./ppx_blob"

--- a/opam
+++ b/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "ppx_blob"
-version: "0.1"
+version: "0.2"
 authors: "John Whitington"
 maintainer: "contact@coherentgraphics.co.uk"
 homepage: "https://github.com/johnwhitington/ppx_blob"


### PR DESCRIPTION
Doesn't really matter that it didn't make it into the release. The stale version number in `META` can be confusing to someone who runs `ocamlfind list | grep ppx_blob`, though.
