### PR TITLE
Check if file exists relative to working directory

### DIFF
--- a/src/ppx_blob.ml
+++ b/src/ppx_blob.ml
@@ -8,10 +8,14 @@ let location_errorf ~loc =
     raise (Location.Error (Location.error ~loc err))
   )
 
-let get_blob ~loc file_name =
+let find_file_path ~loc file_name =
   let dirname = Location.absolute_path loc.Location.loc_start.pos_fname |> Filename.dirname in
-  let file_path = Filename.concat dirname file_name in
+  let absolute_path = Filename.concat dirname file_name in
+  List.find Sys.file_exists [absolute_path; file_name]
+
+let get_blob ~loc file_name =
   try
+    let file_path = find_file_path ~loc file_name in
     let c = open_in_bin file_path in
     let s = String.init (in_channel_length c) (fun _ -> input_char c) in
     close_in c;

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,6 +1,10 @@
 let suite = [
-  "ascii file", `Quick, fun () ->
+  ("path relative to source file", `Quick, fun () ->
     Alcotest.(check string) "file contents" "foo\n" [%blob "test_file"]
+  );
+  ("path relative to working directory", `Quick, fun () ->
+    Alcotest.(check string) "file contents" "foo\n" [%blob "../../test/test_file"]
+  )
 ]
 
 let () =


### PR DESCRIPTION
[`ogen`](https://github.com/nv-vn/ogen) [fails to build](https://ci.ocamllabs.io/log/saved/docker-run-50ed3ffa04ef21076397f61dacc60718/cf97d0ae5a6604654372b9a4b8190625a2c860cd)  after applying https://github.com/johnwhitington/ppx_blob/pull/7. This is due to a change in semantics in `ppx_blob` to support jbuilder/dune. Before #7, `[%blob "foo"]` was interpreted as relative to the current working directory. After #7, it's interpreted as relative to the source file where `%blob` is present.

This PR checks both relative to the working directory and the source file. That should fix the failing build of `ogen`.