### PR TITLE
Opam 2 & dune-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
 ._d/
-*.cmi
-*.cmo
-*.cmx
-*.o
 ppx_blob
 example/quine
 _build
+_opam
 .merlin
 *.install

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+Migrate to dune and dune-release
+
 0.4 2018-02-10
 ---------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,14 @@ test:
 clean:
 	rm -rf _build
 
-.PHONY: test all clean
+tag:
+	dune-release tag
+
+distrib:
+	dune-release distrib
+
+publish:
+	dune-release publish
+
+
+.PHONY: test all clean tag distrib publish

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,2 +1,0 @@
-#use "topfind"
-#require "topkg-jbuilder.auto"

--- a/ppx_blob.descr
+++ b/ppx_blob.descr
@@ -1,3 +1,0 @@
-Include a file as a string at compile time
-
-ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob "filename"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions. 

--- a/ppx_blob.opam
+++ b/ppx_blob.opam
@@ -1,13 +1,19 @@
-opam-version: "1.2"
+opam-version: "2.0"
 authors: "John Whitington"
 maintainer: "contact@coherentgraphics.co.uk"
 homepage: "https://github.com/johnwhitington/ppx_blob"
-dev-repo: "https://github.com/johnwhitington/ppx_blob.git"
+dev-repo: "git+https://github.com/johnwhitington/ppx_blob.git"
 bug-reports: "https://github.com/johnwhitington/ppx_blob/issues/"
-build: [["dune" "build" "-p" name "-j" jobs]]
-build-test: [["dune" "runtest" "-p" name "-j" jobs]]
-depends: [
-  "dune" {build}
-  "ocaml-migrate-parsetree"
-  "alcotest" {test}
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
+depends: [
+  "ocaml"
+  "dune"
+  "ocaml-migrate-parsetree"
+  "alcotest" {with-test}
+]
+synopsis: "Include a file as a string at compile time"
+description:
+  "ppx_blob allows you to include a binary blob from a file as a string. Writing `[%blob \"filename\"]` will replace the string with the contents of the file at compile time. This allows the inclusion of arbitary, possibly compressed, data, without the need to respect OCaml's lexical conventions."


### PR DESCRIPTION
This PR replaces topkg with its dune-optimized fork, dune-release, so a few files can be removed.

Also it updates the OPAM file to the 2.0 format and updates the definitions somewhat to adhere to the current opam-repository policy (e.g. o-r does not consider `dune` a build dependency anymore). I also took the liberty to tweak the `.gitignore` file to ignore local switch directories from OPAM and remove the build artifacts since `dune` always builds in `_build`.