### PR TITLE
Test with OCaml 4.12 and 4.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,19 +13,21 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        ocaml-version:
-          - 4.11.0
-          - 4.10.1
-          - 4.09.1
-          - 4.08.1
+        ocaml-compiler:
+          - 4.13.x
+          - 4.12.x
+          - 4.11.x
+          - 4.10.x
+          - 4.09.x
+          - 4.08.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
       - run: opam pin add ppx_blob.dev . --no-action
       - run: opam depext ppx_blob --yes --with-test
       - run: opam install . --deps-only --with-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
       - run: opam pin add ppx_blob.dev . --no-action
-      - run: opam depext ppx_blob --yes --with-doc --with-test
-      - run: opam install . --deps-only --with-doc --with-test
+      - run: opam depext ppx_blob --yes --with-test
+      - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build @all @runtest


### PR DESCRIPTION
This also upgrades our workflow file to use the latest OCaml GitHub
action (`ocaml/setup-ocaml@v2`).