### PR TITLE
Resolve path as relative path in sandbox rather than using absolute path

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
-(lang dune 1.6)
+(lang dune 1.11)
 (name ppx_blob)
+(explicit_js_mode)

--- a/integration-test/dune-lang-3/src/foo.ml
+++ b/integration-test/dune-lang-3/src/foo.ml
@@ -13,21 +13,21 @@ let () =
     List.exists Result.is_error
       [
         (* Path relative to this file *)
-        (* check ~path:"../root.inc" ~expected:"included-root"
-          ~actual:[%blob "../root.inc"]; *)
-        (* check ~path:"src.inc" ~expected:"included-src" ~actual:[%blob "src.inc"]; *)
+        check ~path:"../root.inc" ~expected:"included-root"
+          ~actual:[%blob "../root.inc"];
+        check ~path:"src.inc" ~expected:"included-src" ~actual:[%blob "src.inc"];
         (* Path relative to build directory *)
         check ~path:"root.inc" ~expected:"included-root"
           ~actual:[%blob "root.inc"];
         check ~path:"src/src.inc" ~expected:"included-src"
           ~actual:[%blob "src/src.inc"];
         (* Ambiguous path *)
-        check ~path:"common.inc" ~expected:"included-common-root" (* violates precedence *)
+        check ~path:"common.inc" ~expected:"included-common-src"
           ~actual:[%blob "common.inc"];
-        (* check ~path:"../common.inc" ~expected:"included-common-root"
-          ~actual:[%blob "../common.inc"]; *)
+        check ~path:"../common.inc" ~expected:"included-common-root"
+          ~actual:[%blob "../common.inc"];
         (* Absolute path *)
-        check ~path:"/etc/hostname" ~expected:(input_line (open_in "/etc/hostname"))
+        check ~path:"/etc/hostname" ~expected:"included-hostname"
           ~actual:[%blob "/etc/hostname"];
       ]
   then exit 1

--- a/ppx_blob.opam
+++ b/ppx_blob.opam
@@ -11,7 +11,7 @@ build: [
 ]
 depends: [
   "ocaml"
-  "dune" {>= "1.6"}
+  "dune" {>= "1.11"}
   "ppxlib"
   "alcotest" {with-test}
 ]

--- a/src/ppx_blob.ml
+++ b/src/ppx_blob.ml
@@ -6,9 +6,9 @@ let location_errorf ~loc =
   )
 
 let find_file_path ~loc file_name =
-  let dirname = Ocaml_common.Location.absolute_path loc.Ocaml_common.Location.loc_start.pos_fname |> Filename.dirname in
-  let absolute_path = Filename.concat dirname file_name in
-  List.find Sys.file_exists [absolute_path; file_name]
+  let dirname = loc.Ocaml_common.Location.loc_start.pos_fname |> Filename.dirname in
+  let relative_path = Filename.concat dirname file_name in
+  List.find Sys.file_exists [relative_path; file_name]
 
 let get_blob ~loc file_name =
   try

--- a/test/subdir/dune
+++ b/test/subdir/dune
@@ -1,5 +1,5 @@
 (tests
  (libraries alcotest)
- (preprocessor_deps (file test_file) (file subdir/test_file))
+ (preprocessor_deps (file test_file) (file ../test_file))
  (preprocess (pps ppx_blob))
  (names test))

--- a/test/subdir/test.ml
+++ b/test/subdir/test.ml
@@ -1,0 +1,14 @@
+let suite = [
+    ("path relative to source file", `Quick, fun () ->
+      Alcotest.(check string) "file contents" "test/subdir/test_file\n" [%blob "test_file"]
+    );
+
+    ("path relative to source file (parent dir)", `Quick, fun () ->
+      Alcotest.(check string) "file contents" "test/test_file\n" [%blob "../test_file"]
+    );
+  ]
+
+let () =
+  Alcotest.run "ppx_blob" [
+    "basic", suite
+  ]

--- a/test/subdir/test_file
+++ b/test/subdir/test_file
@@ -1,0 +1,1 @@
+test/subdir/test_file

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,6 +1,9 @@
 let suite = [
   ("path relative to source file", `Quick, fun () ->
-    Alcotest.(check string) "file contents" "foo\n" [%blob "test_file"]
+    Alcotest.(check string) "file contents" "test/test_file\n" [%blob "test_file"]
+  );
+  ("path relative to source file (subdir)", `Quick, fun () ->
+    Alcotest.(check string) "file contents" "test/subdir/test_file\n" [%blob "subdir/test_file"]
   );
 ]
 

--- a/test/test_file
+++ b/test/test_file
@@ -1,1 +1,1 @@
-foo
+test/test_file


### PR DESCRIPTION
We don't seem to need to use `absolute_path` if the relevant `preprocessor_deps` stanzas are added - in this case it looks like we can just load the file as a relative path from the dune sandbox.

This seems to fix #23 when I've tested it with dune, although I may have missed some subtleties here or broken other non-dune paths if those are supported.

I had to update the `dune-project` `lang` for ppx_blob itself in order to replicate the issue in the tests.