### PR TITLE
Update CI: More recent and fewer intermediate OCaml versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,25 +9,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
-        ocaml-compiler:
-          - 4.13.x
-          - 4.12.x
-          - 4.11.x
-          - 4.10.x
-          - 4.09.x
-          - 4.08.x
-    runs-on: ${{ matrix.os }}
+        config:
+          - {os: macos-latest, ocaml: 4.08.x}
+          - {os: macos-latest, ocaml: 4.14.x}
+          - {os: macos-latest, ocaml: 5.1.x}
+          - {os: ubuntu-latest, ocaml: 4.08.x}
+          - {os: ubuntu-latest, ocaml: 4.09.x}
+          - {os: ubuntu-latest, ocaml: 4.10.x}
+          - {os: ubuntu-latest, ocaml: 4.11.x}
+          - {os: ubuntu-latest, ocaml: 4.12.x}
+          - {os: ubuntu-latest, ocaml: 4.13.x}
+          - {os: ubuntu-latest, ocaml: 4.14.x}
+          - {os: ubuntu-latest, ocaml: 5.0.x}
+          - {os: ubuntu-latest, ocaml: 5.1.x}
+          - {os: windows-latest, ocaml: 4.08.x}
+          - {os: windows-latest, ocaml: 4.14.x}
+    runs-on: ${{ matrix.config.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+      - name: Use OCaml ${{ matrix.config.ocaml }}
         uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          ocaml-compiler: ${{ matrix.config.ocaml }}
       - run: opam pin add ppx_blob.dev . --no-action
       - run: opam depext ppx_blob --yes --with-test
       - run: opam install . --deps-only --with-test


### PR DESCRIPTION
Testing all those intermediate OCaml versions on all the OSes seems wasteful so, for Windows and Ubuntu, I've reduced the set to:

- Earliest supported (4.08.x).
- Latest LTS supported (4.14.x).
- Latest supported (5.1.x): except on Windows where it's unavailable in the `setup-ocaml` action yet.

This is the first time that 4.14 and 5.1 are tested in our CI. 4.11 is still used for our recent integration tests (on Linux).