### PR TITLE
Fix the handling of absolute paths

### DIFF
--- a/integration-test/dune-lang-1/src/foo.ml
+++ b/integration-test/dune-lang-1/src/foo.ml
@@ -27,7 +27,8 @@ let () =
         check ~path:"../common.inc" ~expected:"included-common-root"
           ~actual:[%blob "../common.inc"];
         (* Absolute path *)
-        check ~path:"/etc/hostname" ~expected:"included-hostname"
+        check ~path:"/etc/hostname"
+          ~expected:(input_line (open_in "/etc/hostname"))
           ~actual:[%blob "/etc/hostname"];
       ]
   then exit 1

--- a/integration-test/dune-lang-3/src/foo.ml
+++ b/integration-test/dune-lang-3/src/foo.ml
@@ -27,7 +27,8 @@ let () =
         check ~path:"../common.inc" ~expected:"included-common-root"
           ~actual:[%blob "../common.inc"];
         (* Absolute path *)
-        check ~path:"/etc/hostname" ~expected:"included-hostname"
+        check ~path:"/etc/hostname"
+          ~expected:(input_line (open_in "/etc/hostname"))
           ~actual:[%blob "/etc/hostname"];
       ]
   then exit 1

--- a/integration-test/ocamlopt/src/foo.ml
+++ b/integration-test/ocamlopt/src/foo.ml
@@ -27,7 +27,8 @@ let () =
         check ~path:"../common.inc" ~expected:"included-common-root"
           ~actual:[%blob "../common.inc"];
         (* Absolute path *)
-        check ~path:"/etc/hostname" ~expected:"included-hostname"
+        check ~path:"/etc/hostname"
+          ~expected:(input_line (open_in "/etc/hostname"))
           ~actual:[%blob "/etc/hostname"];
       ]
   then exit 1

--- a/src/ppx_blob.ml
+++ b/src/ppx_blob.ml
@@ -1,35 +1,55 @@
-open Ppxlib
-
 let location_errorf ~loc =
   Format.ksprintf (fun err ->
     raise (Ocaml_common.Location.Error (Ocaml_common.Location.error ~loc err))
   )
 
-let find_file_path ~loc file_name =
-  let dirname = loc.Ocaml_common.Location.loc_start.pos_fname |> Filename.dirname in
-  let relative_path = Filename.concat dirname file_name in
-  List.find Sys.file_exists [relative_path; file_name]
+(* Same as [List.find_map] introduced in OCaml 4.10. *)
+let rec find_map f = function
+  | [] -> None
+  | x :: l ->
+     (match f x with
+       | Some _ as result -> result
+       | None -> find_map f l)
 
-let get_blob ~loc file_name =
+(* Return the list of paths we should try using, in order. *)
+let get_candidate_paths ~loc path =
+  let source_dir = loc.Ocaml_common.Location.loc_start.pos_fname |> Filename.dirname in
+  if Filename.is_relative path then
+    let absolute_path = Filename.concat source_dir path in
+    (* Try the path relative to the source file first, then the one relative to the
+       current working directory (typically, the build directory). *)
+    [absolute_path; path]
+  else
+    (* The user passed an absolute path. Use as is. *)
+    [path]
+
+let read_file path =
   try
-    let file_path = find_file_path ~loc file_name in
-    let c = open_in_bin file_path in
-    let s = String.init (in_channel_length c) (fun _ -> input_char c) in
-    close_in c;
-    s
+    let file = open_in_bin path in
+    Fun.protect
+      ~finally:(fun () -> close_in_noerr file)
+      (fun () ->
+        Some (really_input_string file (in_channel_length file)))
   with _ ->
-    location_errorf ~loc "[%%blob] could not find or load file %s" file_name
+    None
 
-let expand ~ctxt file_name =
+let get_blob ~loc path =
+  match find_map read_file (get_candidate_paths ~loc path) with
+  | Some blob -> blob
+  | None -> location_errorf ~loc "[%%blob] could not find or load file %s" path
+
+let expand ~ctxt path =
+  let open Ppxlib in
   let loc = Expansion_context.Extension.extension_point_loc ctxt in
-  Ast_builder.Default.estring ~loc (get_blob ~loc file_name)
+  Ast_builder.Default.estring ~loc (get_blob ~loc path)
 
 let extension =
+  let open Ppxlib in
   Extension.V3.declare "blob" Extension.Context.expression
     Ast_pattern.(single_expr_payload (estring __))
     expand
 
 let rule = Ppxlib.Context_free.Rule.extension extension
 
-;;
-Driver.register_transformation ~rules:[rule] "ppx_blob"
+let () =
+  Ppxlib.Driver.register_transformation ~rules:[rule] "ppx_blob"

--- a/test/common.inc
+++ b/test/common.inc
@@ -1,0 +1,1 @@
+included-common-root

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,9 @@
 (tests
+ (names test)
  (libraries alcotest)
- (preprocessor_deps (file test_file) (file subdir/test_file))
  (preprocess (pps ppx_blob))
- (names test))
+ (preprocessor_deps
+   (file root.inc)
+   (file common.inc)
+   (file test/common.inc)
+   (file subdir/sub.inc)))

--- a/test/root.inc
+++ b/test/root.inc
@@ -1,0 +1,1 @@
+included-root

--- a/test/subdir/dune
+++ b/test/subdir/dune
@@ -1,5 +1,8 @@
 (tests
+ (names test)
  (libraries alcotest)
- (preprocessor_deps (file test_file) (file ../test_file))
  (preprocess (pps ppx_blob))
- (names test))
+ (preprocessor_deps
+   (file ../root.inc)
+   (file ../common.inc)
+   (file sub.inc)))

--- a/test/subdir/sub.inc
+++ b/test/subdir/sub.inc
@@ -1,0 +1,1 @@
+included-sub

--- a/test/subdir/test.ml
+++ b/test/subdir/test.ml
@@ -1,12 +1,17 @@
 let suite = [
-    ("path relative to source file", `Quick, fun () ->
-      Alcotest.(check string) "file contents" "test/subdir/test_file\n" [%blob "test_file"]
-    );
-
-    ("path relative to source file (parent dir)", `Quick, fun () ->
-      Alcotest.(check string) "file contents" "test/test_file\n" [%blob "../test_file"]
-    );
-  ]
+  ("relative to source file: root", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-root\n" [%blob "../root.inc"]
+  );
+  ("relative to source file: subdir", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-sub\n" [%blob "../subdir/sub.inc"]
+  );
+  ("relative to build directory: root", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-root\n" [%blob "test/root.inc"]
+  );
+  ("relative to build directory: subdir", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-sub\n" [%blob "test/subdir/sub.inc"]
+  );
+]
 
 let () =
   Alcotest.run "ppx_blob" [

--- a/test/subdir/test_file
+++ b/test/subdir/test_file
@@ -1,1 +1,0 @@
-test/subdir/test_file

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,9 +1,18 @@
 let suite = [
-  ("path relative to source file", `Quick, fun () ->
-    Alcotest.(check string) "file contents" "test/test_file\n" [%blob "test_file"]
+  ("relative to source file: root", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-root\n" [%blob "root.inc"]
   );
-  ("path relative to source file (subdir)", `Quick, fun () ->
-    Alcotest.(check string) "file contents" "test/subdir/test_file\n" [%blob "subdir/test_file"]
+  ("relative to source file: subdir", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-sub\n" [%blob "subdir/sub.inc"]
+  );
+  ("relative to build directory: root", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-root\n" [%blob "test/root.inc"]
+  );
+  ("relative to build directory: subdir", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-sub\n" [%blob "test/subdir/sub.inc"]
+  );
+  ("ambiguous path", `Quick, fun () ->
+    Alcotest.(check string) "blob" "included-common-sub\n" [%blob "test/common.inc"]
   );
 ]
 

--- a/test/test/common.inc
+++ b/test/test/common.inc
@@ -1,0 +1,1 @@
+included-common-sub

--- a/test/test_file
+++ b/test/test_file
@@ -1,1 +1,0 @@
-test/test_file


### PR DESCRIPTION
Changes for the user:

- Absolute paths are no longer concatenated with the source directory to form a blob candidate path: they are only treated as absolute paths.
- Minor robustness improvements (reminder: this happens at build time):
  - Reading is done in one pass (instead of checking for existence first).
  - Only the first good path is queried (instead of both).
  - Better I/O error handling.

Internal changes:

- Improved test suite:
  - Test files are easier to recognize (`.inc` extension).
  - Test of the precedence of the source relative path (see "ambiguous" test case).