### PR TITLE
Update CI: Use latest setup-ocaml (v3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest, ocaml: 4.08.x}
+          - {os: macos-latest, ocaml: 4.10.x}  # < OCaml 4.10 is no longer unavailable
           - {os: macos-latest, ocaml: 4.14.x}
-          - {os: macos-latest, ocaml: 5.1.x}
+          - {os: macos-latest, ocaml: 5.2.x}
           - {os: ubuntu-latest, ocaml: 4.08.x}
           - {os: ubuntu-latest, ocaml: 4.09.x}
           - {os: ubuntu-latest, ocaml: 4.10.x}
@@ -21,20 +21,19 @@ jobs:
           - {os: ubuntu-latest, ocaml: 4.13.x}
           - {os: ubuntu-latest, ocaml: 4.14.x}
           - {os: ubuntu-latest, ocaml: 5.0.x}
-          - {os: ubuntu-latest, ocaml: 5.1.x}
-          - {os: windows-latest, ocaml: 4.08.x}
-          - {os: windows-latest, ocaml: 4.14.x}
+          - {os: ubuntu-latest, ocaml: 5.2.x}
+          - {os: windows-latest, ocaml: 4.14.x}  # < OCaml 4.14 will not compile
+          - {os: windows-latest, ocaml: 5.2.x}
     runs-on: ${{ matrix.config.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Use OCaml ${{ matrix.config.ocaml }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.config.ocaml }}
-      - run: opam pin add ppx_blob.dev . --no-action
-      - run: opam depext ppx_blob --yes --with-test
-      - run: opam install . --deps-only --with-test
+      - run: opam pin add --no-action ppx_blob.dev .
+      - run: opam install --deps-only --with-test .
       - run: opam exec -- dune build @all @runtest
   integration-test:
     strategy:
@@ -50,7 +49,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
-        uses: ocaml/setup-ocaml@v2
+        uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 4.11.x
       - run: opam pin add ppx_blob.dev .

--- a/integration-test/dune-lang-1/foo.opam
+++ b/integration-test/dune-lang-1/foo.opam
@@ -16,3 +16,4 @@ depends: [
 ]
 synopsis: "Test case for ppx_blob"
 description: "Test case for ppx_blob"
+license: "Unlicense"

--- a/integration-test/dune-lang-3/foo.opam
+++ b/integration-test/dune-lang-3/foo.opam
@@ -16,3 +16,4 @@ depends: [
 ]
 synopsis: "Test case for ppx_blob"
 description: "Test case for ppx_blob"
+license: "Unlicense"

--- a/integration-test/ocamlbuild/foo.opam
+++ b/integration-test/ocamlbuild/foo.opam
@@ -17,3 +17,4 @@ depends: [
 ]
 synopsis: "Test case for ppx_blob"
 description: "Test case for ppx_blob"
+license: "Unlicense"

--- a/integration-test/ocamlopt/foo.opam
+++ b/integration-test/ocamlopt/foo.opam
@@ -12,3 +12,4 @@ depends: [
 ]
 synopsis: "Test case for ppx_blob"
 description: "Test case for ppx_blob"
+license: "Unlicense"


### PR DESCRIPTION
This ensures we will benefit from improvements and bug fixes for this action.

- On Windows, we unfortunately have to test only from 4.14 on, but those tests on 4.08 were not critical.
- This also fixes an unrelated CI issue with macOS/arm64 builds on 4.08 which was broken.
- The modification of test opam files is not mandatory but avoids warnings in integration tests.