### PR TITLE
Add missing Opam constraint: OCaml >= 4.08

### DIFF
--- a/ppx_blob.opam
+++ b/ppx_blob.opam
@@ -11,7 +11,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "ocaml"
+  "ocaml" {>= "4.08"}
   "dune" {>= "1.11"}
   "ppxlib" {>= "0.9.0"}
   "alcotest" {with-test}


### PR DESCRIPTION
As advised in https://github.com/ocaml/opam-repository/pull/26303.